### PR TITLE
Add stairsplus nodes for sandstone

### DIFF
--- a/mods/stairsplus/init.lua
+++ b/mods/stairsplus/init.lua
@@ -112,6 +112,19 @@ stairsplus.register_stair_and_slab_and_panel_and_micro("stairsplus", "glass", "d
 		default.node_sound_glass_defaults(),
 		true)
 
+stairsplus.register_stair_and_slab_and_panel_and_micro("stairsplus", "sandstone", "default:sandstone",
+		{crumbly=2, cracky=2, not_in_creative_inventory=1, not_in_craft_guide=1},
+		{"default_sandstone.png"},
+		"Sandstone Stairs",
+		"Sandstone Corner",
+		"Sandstone Slab",
+		"Sandstone Wall",
+		"Sandstone Panel",
+		"Sandstone Microblock",
+		"sandstone",
+		default.node_sound_stone_defaults()
+		)
+
 minetest.register_craft({
 	output = "mesecons_pressureplates:pressure_plate_wood_off",
 	recipe = {


### PR DESCRIPTION
I noticed that in mapgen.lua file in the default mod, one of the mapgen aliases was aliased to "stairsplus:stair_sandstone", which didn't exist, at least before this PR. Not much of a problem, as it would have been replaced by "default:sandstone" I think, but its existence was probably intended.