### PR TITLE
Fix for statbar crash with MT 5.5.1

### DIFF
--- a/mods/default/gui.lua
+++ b/mods/default/gui.lua
@@ -5,6 +5,7 @@ local health_bar_definition =
 	position = { x=0.5, y=1 },
 	text = "heart.png",
 	number = 20,
+	item = 20,
 	direction = 0,
 	size = {x=16, y=16},
 	offset = {x=(-9*24)-12, y=-(48+24+8)},


### PR DESCRIPTION
Simple fix for Voxelgarden crashing in Minetest 5.5.1. That release requires "item = " in hudbar definitions and gui.lua didn't have it.